### PR TITLE
allow avatax to be used on the browser

### DIFF
--- a/lib/utils/basic_auth.js
+++ b/lib/utils/basic_auth.js
@@ -3,9 +3,9 @@
  * file: lib/utils/basic_auth.js
  */
 
-export function createBasicAuthHeader(account, licenseKey) {
-  const base64Encoded = new Buffer(`${account}:${licenseKey}`).toString(
-    'base64'
-  );
+export function createBasicAuthHeader( account, licenseKey ) {
+  const isNode = !!( typeof process !== 'undefined' && process.versions && process.versions.node );
+  const authString = `${account}:${licenseKey}`
+  const base64Encoded = isNode ? new Buffer( authString ).toString( 'base64' ) : btoa( authString );
   return `Basic ${base64Encoded}`;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avatax",
-  "version": "18.5.1",
+  "version": "18.5.2",
   "description": "AvaTax v2 SDK for languages using JavaScript",
   "main": "index.js",
   "homepage": "https://github.com/avadev/AvaTax-REST-V2-JS-SDK",


### PR DESCRIPTION
just checks if the method is being run on node, and if so uses default implementation else uses `btoa` to base64 encode the string