### PR TITLE
check for `test/csv` content-type in response

### DIFF
--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -84,7 +84,8 @@ export default class AvaTaxClient {
       },
       body: JSON.stringify(payload)
     }).then(res => {
-      if (res.headers._headers['content-type'][0] === 'application/vnd.ms-excel') {
+      var contentType = res.headers._headers['content-type'][0];
+      if (contentType === 'application/vnd.ms-excel' || contentType === 'test/csv') {
         return res;
       }
       return res.json();

--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -85,7 +85,7 @@ export default class AvaTaxClient {
       body: JSON.stringify(payload)
     }).then(res => {
       var contentType = res.headers._headers['content-type'][0];
-      if (contentType === 'application/vnd.ms-excel' || contentType === 'test/csv') {
+      if (contentType === 'application/vnd.ms-excel' || contentType === 'text/csv') {
         return res;
       }
       return res.json();


### PR DESCRIPTION
It looks like the `DownloadTaxRatesByZipCode` endpoint returns a response header `Content-Type: test/csv` (I'm not sure if this is intentional or not, since this is not a content-type I'm familiar with). From the python client:
```
>>> response = avatax.download_tax_rates_by_zip_code(date='2018-11-30')
>>> response.headers['content-type']
'test/csv'
```
When called from the js client (using the `restCall` function), we end up skipping the current `if` statement and calling `res.json()`, which throws an exception. I've added a check so that the caller can deal with the response directly instead.