### PR TITLE
Fix downloadTaxRatesByZipCode

### DIFF
--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -85,7 +85,8 @@ export default class AvaTaxClient {
       body: JSON.stringify(payload)
     }).then(res => {
       var contentType = res.headers._headers['content-type'][0];
-      if (contentType === 'application/vnd.ms-excel' || contentType === 'text/csv') {
+      // Avatax currently responds with a Content-Type of 'test/csv' NOT 'text/csv'
+      if (contentType === 'application/vnd.ms-excel' || /te[xs]t\/csv/.test(contentType)) {
         return res;
       }
       return res.json();


### PR DESCRIPTION
Avatax server returns Content-Type of 'test/cs' NOT 'text/csv'.
This change should be flexible for any time in the future where the
backend might be fixed to return a proper Content-Type.