### PR TITLE
Fix content type for downloadTaxRatesByZipCode

### DIFF
--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -84,7 +84,9 @@ export default class AvaTaxClient {
       },
       body: JSON.stringify(payload)
     }).then(res => {
-      if (res.headers._headers['content-type'][0] === 'application/vnd.ms-excel') {
+      var contentType = res.headers._headers['content-type'] ? res.headers._headers['content-type'][0] : '';
+
+      if (contentType === 'application/vnd.ms-excel' || /te[xs]t\/csv/.test(contentType)) {
         return res;
       }
       return res.json();


### PR DESCRIPTION
There is a regression in the latest version (19.5.0) that removes the fix made in PRs #72, #77 and #78. This PR re-adds that fix -- without it, the `downloadTaxRatesByZipCode` method will _always_ produce an error (`invalid json response`).