### PR TITLE
BUG: code meant to be defaulting to the prod url but is throwing error

### DIFF
--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -31,10 +31,7 @@ export default class AvaTaxClient {
     this.baseUrl = 'https://rest.avatax.com';
     if (environment == 'sandbox') {
       this.baseUrl = 'https://sandbox-rest.avatax.com';
-    } else if (
-      environment.substring(0, 8) == 'https://' ||
-      environment.substring(0, 7) == 'http://'
-    ) {
+    } else if (  /^(https:\/\/|http:\/\/)/.test(environment) ) {
       this.baseUrl = environment;
     }
     this.clientId =

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -24,5 +24,26 @@ describe('Avatax Client', () => {
     // expect(client.licenseKey).toBe(licenseKey);
     // todo: verify base64 computed header from accountId + licenseKey
   });
+
+  it('should handle various environment settings', () => {
+
+    const testCases = [
+      { environment:'sandbox', expected: 'https://sandbox-rest.avatax.com' },
+      { environment:'production', expected: 'https://rest.avatax.com' },
+      { environment: undefined, expected: 'https://rest.avatax.com' },
+      { environment:'http://specific-url' , expected: 'http://specific-url' },
+      { environment:'https://specific-https-url' , expected: 'https://specific-https-url' }, 
+    ]
+    testCases.forEach(({ environment, expected })=>{
+
+      const client = new Avatax({ 
+        appName:'myapp', 
+        appVersion:'1.0',
+        machineName: 'test-run',
+        environment
+      })
+      expect(client.baseUrl).toBe(expected);
+    })
+  });
 });
 


### PR DESCRIPTION
If environment isn't defined you get the error
`TypeError: Cannot read property 'substring' of undefined
    at new AvaTaxClient`

It's not a big bug but the error isn't helpful and it looks like the intent of the code is to always default to the rest url. 