### PR TITLE
AS-5: Fixing JS SDK tests

### DIFF
--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -34,8 +34,9 @@ export default class AvaTaxClient {
     if (environment == 'sandbox') {
       this.baseUrl = 'https://sandbox-rest.avatax.com';
     } else if (
-      environment.substring(0, 8) == 'https://' ||
-      environment.substring(0, 7) == 'http://'
+      typeof environment !== "undefined" &&
+      (environment.substring(0, 8) == 'https://' ||
+      environment.substring(0, 7) == 'http://')
     ) {
       this.baseUrl = environment;
     }

--- a/test/address.spec.js
+++ b/test/address.spec.js
@@ -76,7 +76,6 @@ describe('Address resolve Tests', () => {
             expect(res.validatedAddresses[0]).toBeDefined();
             expect(res.validatedAddresses[0].latitude).toBeDefined();
             expect(res.validatedAddresses[0].latitude).toEqual(42.144481999999996);
-            expect(res.taxAuthorities[0].code).toEqual(true);
             expect(res.coordinates).toBeDefined();
             expect(res.coordinates.longitude).toBeDefined();
             expect(res.coordinates.longitude).toEqual(-88.320204);

--- a/test/fixtures/address_response.js
+++ b/test/fixtures/address_response.js
@@ -34,7 +34,6 @@ export default {
         latitude: 42.144481999999996,
         longitude: -88.320204
       },
-      ,
       {
         addressType: 'StreetOrResidentialAddress',
         line1: '1510 Foster Cir',


### PR DESCRIPTION
This pull request will fix the following errors / tests:
- In **address.spec.js** : TaxAuthorities currently doesn't expose fild named "code", hence removing it from "expect" condition.
- In **client.spec.js** : As per the test case, we can get an input of "undefined" and we should still return the base URL of production.
This change would cover this scenario and not fail the test case by returning the expected PROD url. Currently the test case fails with error "Cannot read properties of undefined (reading 'substring')"
- Fixed one of the lint errors