### PR TITLE
Make visible response status in the second 'then'

### DIFF
--- a/lib/AvaTaxClient.js
+++ b/lib/AvaTaxClient.js
@@ -102,6 +102,7 @@ export default class AvaTaxClient {
         return null;
       }
     }
+      res.body.responseStatus = res.status;
       return res.json();
     }).then(json => {
         // handle error
@@ -110,6 +111,7 @@ export default class AvaTaxClient {
           ex.code = json.error.code;
           ex.target = json.error.target;
           ex.details = json.error.details;
+          ex.responseStatus = json.responseStatus;
           throw ex;
         } else {
           return json;


### PR DESCRIPTION
In Avalara documentation says:
...AvaTax API call produces an error, it responds using the standard HTTP error response codes
- 400-499 Client errors
- 500-599 Server errors

[Handling Error Messages](https://developer.avalara.com/avatax/dev-guide/getting-started-with-avatax/troubleshooting/)

But we can not get the response status since Avalara is returning response.json(), so the subsequent `then` and `catch` only gets the result of response.json() which is the body of the response. Therefore the response `status` is not visible in the second `then`

