### PR TITLE
Fix for JS SDK lint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,11 +10,8 @@
     "jest": true
   },
   "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module",
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true
-    }
+    "ecmaVersion": 9,
+    "sourceType": "module"
   },
   "rules": {
     "quotes": [2, "single", {

--- a/test/fixtures/address_response.js
+++ b/test/fixtures/address_response.js
@@ -19,8 +19,8 @@ export default {
         region: 'IL',
         country: 'US',
         postalCode: '60102-6659',
-        latitude: 42.1444819999999969878987,
-        longitude: -867678687688.320204
+        latitude: 43.144481,
+        longitude: -86.390206
       },
       {
         addressType: 'StreetOrResidentialAddress',
@@ -43,8 +43,8 @@ export default {
         region: 'IL',
         country: 'US',
         postalCode: '60102-6659',
-        latitude: 938745837485739745398475,
-        longitude: 320204
+        latitude: 49.144481887,
+        longitude: -89.390206
       }
     ],
     coordinates: { latitude: 42.144481999999996, longitude: -88.320204 },


### PR DESCRIPTION
This will fix the following errors:

**In address_response.js :**
  22:19  error  This number literal will lose precision at runtime  no-loss-of-precision
  23:21  error  This number literal will lose precision at runtime  no-loss-of-precision
  46:19  error  This number literal will lose precision at runtime  no-loss-of-precision

**In load_creds.js:**
  33:7  error  Parsing error: Unexpected token ..